### PR TITLE
Added myself as contributor. Changes to bibtex.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,18 @@ The folder `experiments` contains the commands to reproduce the results of the m
 - [Andrea Cavallo](https://github.com/andrea-cavallo-98)
 - [Claas Grohnfeldt](https://github.com/claas-grohnfeldt)
 - [Michele Russo](https://github.com/mik1904)
+- [Giulio Lovisotto](https://giuliolovisotto.github.io)
 
 ## Citation
 
 If you find this code useful, please cite
 
 ```
-@INPROCEEDINGS{Cava2306:GCNH,
-AUTHOR="Andrea Cavallo and Luca Vassio and Claas Grohnfeldt and Michele Russo and Giulio Lovisotto",
-TITLE="{GCNH:} A Simple Method for Representation Learning on Heterophilous Graphs",
-BOOKTITLE="2023 International Joint Conference on Neural Networks (IJCNN) (IJCNN 2023)",
-ADDRESS="Queensland, Australia",
-PAGES=8,
-DAYS="17",
-MONTH=jun,
-YEAR=2023,
+@inproceedings{cavallo2023gcnh,
+  title={{GCNH:} A Simple Method for Representation Learning on Heterophilous Graphs},
+  author={Cavallo, Andrea and Grohnfeldt, Claas and Russo, Michele and Lovisotto, Giulio and Vassio, Luca},
+  booktitle={2023 International Joint Conference on Neural Networks (IJCNN)},
+  year={2022},
+  organization={IEEE}
 }
 ```


### PR DESCRIPTION
Hi Andrea, 

I saw you created a bibtex citation but I would strongly recommend to stick to the format I added now. You want to make sure there are as fewer versions of the bibtex as possible, different websites might not merge them properly, so they might index the id alone.

I added the citation in a format that might resemble what you will find on google scholar when the paper is crawled after it appears in the proceedings. If you look at [IJCNN22 papers](https://ieeexplore.ieee.org/xpl/conhome/9891857/proceeding?isnumber=9889787&sortType=paper-citations) and find the [most cited one in scholar](https://scholar.googleusercontent.com/scholar.bib?q=info:B2u62TU5hDAJ:scholar.google.com/&output=citation&scisdr=CptAUVjKEO6piLdns3g:AJ9-iYsAAAAAZEliq3hxoA60cbnxZ3wzEOarEP0&scisig=AJ9-iYsAAAAAZEliq_XLDzW2DMrahztRkyDcvv8&scisf=4&ct=citation&cd=-1&hl=en) you will see that the format is the same.

Other minor notes:
 * the order of authors in the bibtex is important, so it should match what you find in the paper.
 * in general, the "PAGES" attribute in the bibtex does not refer to how many pages the paper has (that would be "NUM_PAGES"), but at which page in the entire printed conference proceedings your article appears (so it could be that you article starts at page 50 and ends at page 59 -  you'd have `pages={50--59}`). I don't think people care anymore now that everything is online.
