### PR TITLE
Some more clarifying changes to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,25 @@
 # GCNH: A Simple Method For Representation Learning On Heterophilous Graphs
 
-This repository contains the implementation of GCNH, the model described in our work *GCNH: A Simple Method For Representation Learning On Heterophilous Graphs*, accepted at IJCNN 2023 ([preprint](https://arxiv.org/abs/2304.10896)). 
+This repository contains the implementation of Graph Convolutional Network for Heterophily, the model described in our work *GCNH: A Simple Method For Representation Learning On Heterophilous Graphs*, accepted at IJCNN 2023 ([preprint](https://arxiv.org/abs/2304.10896)). 
 
 ## Description
 
-GCNH extends GNNs' representation capabilities on heterophilous graphs by learning two different functions to encode center node and neighborhood messages. These two encoding are merged into the final node embedding using a balancing coefficient β. In this way, the model can flexibly choose to assign more or less importance to the neighborhood, depending on how informative it is. Our experiments show that GCNH achieves state-of-the-art performance on 4 out of the 8 graph datasets used.
+GCNH extends Graph Neural networks' representation capabilities on by learning two different functions to encode center node and neighborhood messages. These two encoding are merged into the final node embedding using a convex combination with a learned coefficient β. The layer propagation rule in GCNH works as follows: 
+
+$$h^l_u = (1-\beta)\bigoplus_{v \in \mathcal{N_u}}\left[ \sigma(h^{\ell-1}_v W_2) \right] + \beta\sigma(h^{\ell-1}_u W_1).$$
+
+For a center node, GCNH flexibly assigns more or less importance to the neighborhood, depending on how informative neighbors are - this design greatly improves learning on **heterophilous** graphs. Experiments show that GCNH achieves state-of-the-art performance on 4 out of the 8 graph datasets used.
 
 ![GCNH_layer](./figures/gcnh_layer_background.svg)  
 
 ## Usage
 
-The folder `experiments` contains the commands to reproduce the results of the main table of the paper and to test GCNH on the synthetic dataset used in the paper.
+### Requirements
+ * Python=3.9
+ * requirements.txt (`pip install -r requirements.txt`)
+ * [torch-scatter](https://pypi.org/project/torch-scatter/) (e.g., `pip install torch_scatter -f https://data.pyg.org/whl/torch-2.0.0+{device}.html`)
+
+The folder [GCNH/experiments](https://github.com/SmartData-Polito/GCNH/tree/main/experiments) contains the commands to reproduce the results of the main table of the paper and to test GCNH on the synthetic dataset used in the paper.
 
 ## Contributors
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pandas==1.4.3
 scikit_learn==1.1.1
 scipy==1.8.1
 torch==2.0.0
-torch_scatter==2.1.1+pt20cu117
+# torch_scatter==2.1.1+pt20cu117
 tqdm==4.64.0


### PR DESCRIPTION
## Usage
I could not install `torch_scatter` with `pip install torch-scatter` so I'd remove it from requirements.txt and link to the repo to see how one can install it.

## Description
I added some clarifications to the main readme, and added the layer propagation rule in GCNH in [formulas](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions)

